### PR TITLE
Add dry-run,no-color,with-breakpoints,continue-on-error functionality

### DIFF
--- a/demo.go
+++ b/demo.go
@@ -50,6 +50,9 @@ const (
 	// FlagImmediate is the flag for disabling the text animations.
 	FlagImmediate = "immediate"
 
+	// DryRun
+	FlagDryRun = "dry-run"
+
 	// FlagSkipSteps is the flag for skipping n amount of steps.
 	FlagSkipSteps = "skip-steps"
 
@@ -74,6 +77,11 @@ func New() *Demo {
 			Value:   true,
 			Usage: "run the demo in automatic mode, " +
 				"where every step gets executed automatically",
+		},
+		&cli.BoolFlag{
+			Name:  FlagDryRun,
+			Value: true,
+			Usage: "run the demo in prints only commands",
 		},
 		&cli.DurationFlag{
 			Name:    FlagAutoTimeout,

--- a/demo.go
+++ b/demo.go
@@ -44,14 +44,17 @@ const (
 	// any end.
 	FlagContinuously = "continuously"
 
+	// DryRun
+	FlagDryRun = "dry-run"
+
 	// FlagHideDescriptions is the flag for hiding the descriptions.
 	FlagHideDescriptions = "hide-descriptions"
 
 	// FlagImmediate is the flag for disabling the text animations.
 	FlagImmediate = "immediate"
 
-	// DryRun
-	FlagDryRun = "dry-run"
+	// NoColor true to print without colors, special characters
+	FlagNoColor = "no-color"
 
 	// FlagSkipSteps is the flag for skipping n amount of steps.
 	FlagSkipSteps = "skip-steps"
@@ -81,7 +84,11 @@ func New() *Demo {
 		&cli.BoolFlag{
 			Name:  FlagDryRun,
 			Value: true,
-			Usage: "run the demo in prints only commands",
+			Usage: "run the demo and only prints the commands",
+		},
+		&cli.BoolFlag{
+			Name:  FlagNoColor,
+			Usage: "run the demo and output to be without colors",
 		},
 		&cli.DurationFlag{
 			Name:    FlagAutoTimeout,

--- a/demo.go
+++ b/demo.go
@@ -33,18 +33,18 @@ const (
 	// enabled.
 	FlagAutoTimeout = "auto-timeout"
 
-	// FlagBreakPoint is the flag for doing`auto` but with breakpoint
+	// FlagBreakPoint is the flag for doing`auto` but with breakpoint.
 	FlagBreakPoint = "with-breakpoints"
 
 	// FlagContinueOnError is the flag for steps continue running if
-	// there is an error
+	// there is an error.
 	FlagContinueOnError = "continue-on-error"
 
 	// FlagContinuously is the flag for running the demos continuously without
 	// any end.
 	FlagContinuously = "continuously"
 
-	// DryRun
+	// DryRun only prints the command in the stdout.
 	FlagDryRun = "dry-run"
 
 	// FlagHideDescriptions is the flag for hiding the descriptions.
@@ -53,7 +53,7 @@ const (
 	// FlagImmediate is the flag for disabling the text animations.
 	FlagImmediate = "immediate"
 
-	// NoColor true to print without colors, special characters
+	// NoColor true to print without colors, special characters for writing into file.
 	FlagNoColor = "no-color"
 
 	// FlagSkipSteps is the flag for skipping n amount of steps.
@@ -77,7 +77,6 @@ func New() *Demo {
 		&cli.BoolFlag{
 			Name:    FlagAuto,
 			Aliases: []string{"a"},
-			Value:   true,
 			Usage: "run the demo in automatic mode, " +
 				"where every step gets executed automatically",
 		},

--- a/demo.go
+++ b/demo.go
@@ -33,6 +33,13 @@ const (
 	// enabled.
 	FlagAutoTimeout = "auto-timeout"
 
+	// FlagBreakPoint is the flag for doing`auto` but with breakpoint
+	FlagBreakPoint = "with-breakpoints"
+
+	// FlagContinueOnError is the flag for steps continue running if
+	// there is an error
+	FlagContinueOnError = "continue-on-error"
+
 	// FlagContinuously is the flag for running the demos continuously without
 	// any end.
 	FlagContinuously = "continuously"
@@ -64,6 +71,7 @@ func New() *Demo {
 		&cli.BoolFlag{
 			Name:    FlagAuto,
 			Aliases: []string{"a"},
+			Value:   true,
 			Usage: "run the demo in automatic mode, " +
 				"where every step gets executed automatically",
 		},
@@ -71,7 +79,15 @@ func New() *Demo {
 			Name:    FlagAutoTimeout,
 			Aliases: []string{"t"},
 			Usage:   "the timeout to be waited when `auto` is enabled",
-			Value:   3 * time.Second,
+			Value:   1 * time.Second,
+		},
+		&cli.BoolFlag{
+			Name:  FlagBreakPoint,
+			Usage: "breakpoint",
+		},
+		&cli.BoolFlag{
+			Name:  FlagContinueOnError,
+			Usage: "continue if there a step fails",
 		},
 		&cli.BoolFlag{
 			Name:    FlagContinuously,

--- a/run.go
+++ b/run.go
@@ -235,8 +235,8 @@ func (s *step) echo(current, max int) {
 			prepared = append(
 				prepared,
 				p(
-					"# %s [%d/%d]:\n",
-					x, current, max,
+					"# %s [%d/%d]%s\n",
+					x, current, max, colon,
 				),
 			)
 		} else {
@@ -259,8 +259,8 @@ func (s *step) execute() error {
 		p = fmt.Sprintf
 	}
 
-	cmdString := p("%s", strings.Join(s.command, " \\\n    "))
-	s.print("```\n" + cmdString + "\n```\n")
+	cmdString := p("> %s", strings.Join(s.command, " \\\n    "))
+	s.print(cmdString)
 	if err := s.waitOrSleep(); err != nil {
 		return fmt.Errorf("unable to execute step: %v: %w", s, err)
 	}


### PR DESCRIPTION
As part of me using the library for demos, I had to modify the library code to add the following functions

```
--dry-run                     run the demo and only prints the commands (default: true)
--no-color                    run the demo and output to be without colors (default: false)
--with-breakpoints            breakpoint (default: false)
--continue-on-error           continue if there a step fails (default: false)
```
This is a fully draft PR. In case you want, I can work towards  improving the code for merging. Thanks