### PR TITLE
Add CLI option to override shell used

### DIFF
--- a/demo.go
+++ b/demo.go
@@ -45,6 +45,9 @@ const (
 
 	// FlagSkipSteps is the flag for skipping n amount of steps.
 	FlagSkipSteps = "skip-steps"
+
+	// FlagShell is the flag for defining the shell that is used to execute the command(s).
+	FlagShell = "shell"
 )
 
 // New creates a new Demo instance.
@@ -89,6 +92,11 @@ func New() *Demo {
 			Name:    FlagSkipSteps,
 			Aliases: []string{"s"},
 			Usage:   "skip the amount of initial steps within the demo",
+		},
+		&cli.StringFlag{
+			Name:        FlagShell,
+			Usage:       "define the shell that is used to execute the command(s)",
+			DefaultText: "bash",
 		},
 	}
 

--- a/util.go
+++ b/util.go
@@ -8,7 +8,7 @@ import (
 // This utility function can be used during setup or cleanup.
 func Ensure(commands ...string) error {
 	for _, c := range commands {
-		cmd := exec.Command(bash, "-c", c)
+		cmd := exec.Command("sh", "-c", c)
 		cmd.Stderr = nil
 		cmd.Stdout = nil
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
- Default to `sh` for `Ensure`
- Add CLI option to override shell used

Closes #117.
