### PR TITLE
Add working directory support for steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,33 @@ func cleanup(ctx context.Context, _ *cli.Command) error {
 }
 ```
 
+## Working directory
+
+The working directory for command execution can be configured per run or changed
+between steps:
+
+```go
+func example() *Run {
+	r := NewRun("Working Directory Demo")
+
+	// Set the initial working directory for all steps
+	r.SetWorkDir("/tmp")
+
+	r.Step(S("Show current directory"), S("pwd"))
+
+	// Change the working directory between steps
+	r.Chdir("/home")
+
+	r.Step(S("Now in a different directory"), S("pwd"))
+
+	return r
+}
+```
+
+`SetWorkDir` sets the initial working directory for the run. `Chdir` inserts a
+step that changes the working directory for all subsequent steps. If no working
+directory is set, commands run in the current process directory.
+
 ## Terminal raw mode
 
 During the typewriter animation and while waiting for user input, the terminal

--- a/run.go
+++ b/run.go
@@ -38,11 +38,13 @@ type Run struct {
 	options     Options
 	setup       func() error
 	cleanup     func() error
+	dir         string
 }
 
 type step struct {
 	text, command         []string
 	canFail, isBreakPoint bool
+	dir                   string
 }
 
 // Options specify the run options.
@@ -164,19 +166,29 @@ func (r *Run) Cleanup(cleanupFn func() error) {
 	r.cleanup = cleanupFn
 }
 
+// SetWorkDir sets the working directory for all steps in this run.
+func (r *Run) SetWorkDir(dir string) {
+	r.dir = dir
+}
+
 // Step creates a new step on the provided run.
 func (r *Run) Step(text, command []string) {
-	r.steps = append(r.steps, step{text, command, false, false})
+	r.steps = append(r.steps, step{text: text, command: command})
 }
 
 // StepCanFail creates a new step which can fail on execution.
 func (r *Run) StepCanFail(text, command []string) {
-	r.steps = append(r.steps, step{text, command, true, false})
+	r.steps = append(r.steps, step{text: text, command: command, canFail: true})
+}
+
+// Chdir creates a step that changes the working directory for subsequent steps.
+func (r *Run) Chdir(dir string) {
+	r.steps = append(r.steps, step{dir: dir})
 }
 
 // BreakPoint creates a new step which can fail on execution.
 func (r *Run) BreakPoint() {
-	r.steps = append(r.steps, step{nil, nil, true, true})
+	r.steps = append(r.steps, step{canFail: true, isBreakPoint: true})
 }
 
 // Run executes the run in the provided CLI context.
@@ -214,8 +226,20 @@ func (r *Run) RunWithOptions(opts *Options) error {
 		return err
 	}
 
-	for i, s := range r.steps {
-		if r.options.SkipSteps > i {
+	visibleSteps := r.countVisibleSteps()
+	current := 0
+
+	for _, s := range r.steps {
+		// Always apply Chdir steps, even when skipped
+		if s.dir != "" {
+			r.dir = s.dir
+
+			continue
+		}
+
+		current++
+
+		if r.options.SkipSteps >= current {
 			continue
 		}
 
@@ -223,7 +247,7 @@ func (r *Run) RunWithOptions(opts *Options) error {
 			s.canFail = true
 		}
 
-		if err := s.run(r, i+1, len(r.steps)); err != nil {
+		if err := s.run(r, current, visibleSteps); err != nil {
 			return err
 		}
 	}
@@ -270,6 +294,18 @@ func write(w io.Writer, str string) error {
 	}
 
 	return nil
+}
+
+func (r *Run) countVisibleSteps() int {
+	count := 0
+
+	for _, s := range r.steps {
+		if s.dir == "" {
+			count++
+		}
+	}
+
+	return count
 }
 
 func (s *step) run(r *Run, current, maximum int) error {
@@ -323,6 +359,7 @@ func (s *step) execute(r *Run) error {
 
 	cmd.Stderr = r.out
 	cmd.Stdout = r.out
+	cmd.Dir = r.dir
 
 	displayCommand := strings.Join(s.command, " \\\n    ")
 	cmdString := r.options.greenSprintf("> %s", displayCommand)

--- a/run_test.go
+++ b/run_test.go
@@ -422,6 +422,79 @@ var _ = Describe("Run", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("should succeed to run with SetWorkDir", func() {
+		// Given
+		sut.SetWorkDir("/tmp")
+		sut.Step(demo.S("Working dir test"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("/tmp"))
+	})
+
+	It("should succeed to run with Chdir between steps", func() {
+		// Given
+		sut.Step(demo.S("First step"), demo.S("pwd"))
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("After chdir"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("/tmp"))
+	})
+
+	It("should apply Chdir even when steps are skipped", func() {
+		// Given
+		opts.SkipSteps = 1
+
+		sut.Step(demo.S("Skipped step"), demo.S("echo skipped"))
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("After chdir"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).ToNot(ContainSubstring("Skipped step"))
+		Expect(out.String()).To(ContainSubstring("/tmp"))
+	})
+
+	It("should not count Chdir in step numbering", func() {
+		// Given
+		sut.Step(demo.S("First"), demo.S("echo one"))
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("Second"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("[1/2]"))
+		Expect(out.String()).To(ContainSubstring("[2/2]"))
+	})
+
+	It("should succeed to run with Chdir and dry-run", func() {
+		// Given
+		opts.DryRun = true
+
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("Dry run chdir"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("should properly handle empty title", func() {
 		// Given
 		emptySut := demo.NewRun("")


### PR DESCRIPTION
## Summary

- Add `SetWorkDir` to set the initial working directory for a run
- Add `Chdir` to change the working directory between steps
- Both work by setting `cmd.Dir` on the subprocess

Closes #145