### PR TITLE
Add environment variables, stdin passthrough, and Chdir display

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,28 @@ func example() *Run {
 ```
 
 `SetWorkDir` sets the initial working directory for the run. `Chdir` inserts a
-step that changes the working directory for all subsequent steps. If no working
-directory is set, commands run in the current process directory.
+step that changes the working directory for all subsequent steps and displays
+`> cd <dir>` in the output. If no working directory is set, commands run in
+the current process directory.
+
+## Environment variables
+
+Custom environment variables can be set for all steps in a run:
+
+```go
+func example() *Run {
+	r := NewRun("Environment Demo")
+
+	r.SetEnv("MY_VAR=hello", "OTHER_VAR=world")
+
+	r.Step(S("Show env"), S("echo $MY_VAR $OTHER_VAR"))
+
+	return r
+}
+```
+
+Variables are appended to the current process environment. Multiple calls to
+`SetEnv` accumulate variables.
 
 ## Terminal raw mode
 

--- a/demo.go
+++ b/demo.go
@@ -12,6 +12,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+// Demo is the main type for creating command line demos. It wraps a
+// cli.Command and manages a set of runs that can be selected via flags.
 type Demo struct {
 	*cli.Command
 

--- a/run.go
+++ b/run.go
@@ -39,6 +39,7 @@ type Run struct {
 	setup       func() error
 	cleanup     func() error
 	dir         string
+	env         []string
 }
 
 type step struct {
@@ -171,6 +172,13 @@ func (r *Run) SetWorkDir(dir string) {
 	r.dir = dir
 }
 
+// SetEnv sets environment variables for all steps in this run.
+// Each entry should be in the form "KEY=VALUE". These are appended
+// to the current process environment.
+func (r *Run) SetEnv(env ...string) {
+	r.env = append(r.env, env...)
+}
+
 // Step creates a new step on the provided run.
 func (r *Run) Step(text, command []string) {
 	r.steps = append(r.steps, step{text: text, command: command})
@@ -233,6 +241,13 @@ func (r *Run) RunWithOptions(opts *Options) error {
 		// Always apply Chdir steps, even when skipped
 		if s.dir != "" {
 			r.dir = s.dir
+
+			if !r.options.HideDescriptions {
+				cdStr := r.options.greenSprintf("> cd %s", s.dir)
+				if err := write(r.out, cdStr+"\n"); err != nil {
+					return err
+				}
+			}
 
 			continue
 		}
@@ -359,7 +374,12 @@ func (s *step) execute(r *Run) error {
 
 	cmd.Stderr = r.out
 	cmd.Stdout = r.out
+	cmd.Stdin = r.inFile
 	cmd.Dir = r.dir
+
+	if len(r.env) > 0 {
+		cmd.Env = append(os.Environ(), r.env...)
+	}
 
 	displayCommand := strings.Join(s.command, " \\\n    ")
 	cmdString := r.options.greenSprintf("> %s", displayCommand)

--- a/run_test.go
+++ b/run_test.go
@@ -495,6 +495,61 @@ var _ = Describe("Run", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("should succeed to run with SetEnv", func() {
+		// Given
+		sut.SetEnv("DEMO_TEST_VAR=hello123")
+		sut.Step(demo.S("Env test"), demo.S("echo $DEMO_TEST_VAR"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("hello123"))
+	})
+
+	It("should succeed to run with multiple SetEnv calls", func() {
+		// Given
+		sut.SetEnv("VAR1=first")
+		sut.SetEnv("VAR2=second")
+		sut.Step(demo.S("Multi env"), demo.S("echo $VAR1 $VAR2"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("first second"))
+	})
+
+	It("should display Chdir as a command", func() {
+		// Given
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("After chdir"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).To(ContainSubstring("cd /tmp"))
+	})
+
+	It("should hide Chdir display when descriptions are hidden", func() {
+		// Given
+		opts.HideDescriptions = true
+
+		sut.Chdir("/tmp")
+		sut.Step(demo.S("After chdir"), demo.S("pwd"))
+
+		// When
+		err := sut.RunWithOptions(&opts)
+
+		// Then
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.String()).ToNot(ContainSubstring("cd /tmp"))
+	})
+
 	It("should properly handle empty title", func() {
 		// Given
 		emptySut := demo.NewRun("")


### PR DESCRIPTION
## Summary

- Add `SetEnv` to configure environment variables for step commands
- Pass stdin through to step subprocesses for interactive commands
- Display `Chdir` steps as `> cd <dir>` in the output
- Add godoc comment on `Demo` struct